### PR TITLE
Adding `client.RawUpdateSubscription` method

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -4,12 +4,14 @@ import (
 	"net/url"
 )
 
-// ClientInterface defines exported methods
+// ClientInterface defines the interface needed to integrate with Mailchimps
+// API V3.0.
 type ClientInterface interface {
 	// Exported methods
 	CheckSubscription(listID string, email string) (*MemberResponse, error)
 	Subscribe(listID string, email string, mergeFields map[string]interface{}) (*MemberResponse, error)
 	UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error)
+	RawUpdateSubscription(listID, email string, params map[string]interface{}) (*MemberResponse, error)
 	SetBaseURL(baseURL *url.URL)
 	GetBaseURL() *url.URL
 }

--- a/client_mock.go
+++ b/client_mock.go
@@ -57,13 +57,13 @@ func (_m *ClientMock) Subscribe(listID string, email string, mergeFields map[str
 	return r0, r1
 }
 
-// UpdateSubscription ...
-func (_m *ClientMock) UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error) {
-	ret := _m.Called(listID, email, mergeFields)
+// RawUpdateSubscription ...
+func (_m *ClientMock) RawUpdateSubscription(listID, email string, params map[string]interface{}) (*MemberResponse, error) {
+	ret := _m.Called(listID, email, params)
 
 	var r0 *MemberResponse
 	if rf, ok := ret.Get(0).(func(string, string, map[string]interface{}) *MemberResponse); ok {
-		r0 = rf(listID, email, mergeFields)
+		r0 = rf(listID, email, params)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*MemberResponse)
@@ -72,12 +72,17 @@ func (_m *ClientMock) UpdateSubscription(listID string, email string, status str
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string, map[string]interface{}) error); ok {
-		r1 = rf(listID, email, mergeFields)
+		r1 = rf(listID, email, params)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
+}
+
+// UpdateSubscription ...
+func (_m *ClientMock) UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error) {
+	return _m.RawUpdateSubscription(listID, email, mergeFields)
 }
 
 // SetBaseURL ...

--- a/update_subscription.go
+++ b/update_subscription.go
@@ -5,22 +5,47 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/splicers/go-mailchimp/status"
 )
 
-// UpdateSubscription ...
+// UpdateSubscription is deprecated and you should use RawUpdateSubscription.
 func (c *Client) UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error) {
-	// Hash email
-	emailMD5 := fmt.Sprintf("%x", md5.Sum([]byte(email)))
-	// Make request
 	params := map[string]interface{}{
 		"email_address": email,
 		"status":        status,
 		"merge_fields":  mergeFields,
 	}
+
+	return c.RawUpdateSubscription(listID, email, params)
+}
+
+// RawUpdateSubscription will update the subscription identified by `email` in
+// the list with ID `listID`. You can send any parameters from the ones that
+// are documented in Mailchimps docs.
+//
+// This is a better version of the deprecated UpdateSubscription.
+//
+// http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash
+func (c *Client) RawUpdateSubscription(listID, email string, params map[string]interface{}) (*MemberResponse, error) {
+	// Mailchimp uses the MD5 of the email as the subscription's key.
+	emailMD5 := fmt.Sprintf("%x", md5.Sum([]byte(email)))
+
+	// Default parameters for subscriptions
+	reqParams := map[string]interface{}{
+		"email_address": email,
+		"status":        status.Subscribed,
+	}
+
+	// Override default parameters with whatever was sent in `params` argument.
+	for k, v := range params {
+		reqParams[k] = v
+	}
+
 	resp, err := c.do(
 		"PUT",
 		fmt.Sprintf("/lists/%s/members/%s", listID, emailMD5),
-		&params,
+		&reqParams,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds a new method to interact with updating subscriptions
via Mailchimp's API 3.0.

The `client.UpdateSubscription` is very rigid and doesn't allow you to
control the parameters sent to Mailchimp. This "raw" API call should
replace that.

The new method allows you to send any parameter that the Mailchimp API
takes.