### PR TITLE
Update `client.UpdateSubscription` to allow any parameter

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -9,7 +9,7 @@ type ClientInterface interface {
 	// Exported methods
 	CheckSubscription(listID string, email string) (*MemberResponse, error)
 	Subscribe(listID string, email string, mergeFields map[string]interface{}) (*MemberResponse, error)
-	UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error)
+	UpdateSubscription(listID string, email string, params map[string]interface{}) (*MemberResponse, error)
 	SetBaseURL(baseURL *url.URL)
 	GetBaseURL() *url.URL
 }

--- a/client_mock.go
+++ b/client_mock.go
@@ -58,12 +58,12 @@ func (_m *ClientMock) Subscribe(listID string, email string, mergeFields map[str
 }
 
 // UpdateSubscription ...
-func (_m *ClientMock) UpdateSubscription(listID string, email string, status string, mergeFields map[string]interface{}) (*MemberResponse, error) {
-	ret := _m.Called(listID, email, mergeFields)
+func (_m *ClientMock) UpdateSubscription(listID, email string, params map[string]interface{}) (*MemberResponse, error) {
+	ret := _m.Called(listID, email, params)
 
 	var r0 *MemberResponse
 	if rf, ok := ret.Get(0).(func(string, string, map[string]interface{}) *MemberResponse); ok {
-		r0 = rf(listID, email, mergeFields)
+		r0 = rf(listID, email, params)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*MemberResponse)
@@ -72,7 +72,7 @@ func (_m *ClientMock) UpdateSubscription(listID string, email string, status str
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string, map[string]interface{}) error); ok {
-		r1 = rf(listID, email, mergeFields)
+		r1 = rf(listID, email, params)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This commit changes the `UpdateSubscription` method to allow sending any
accepted parameter to Mailchimp's API.

Before this change, the API would only accept changing the subscription
status, and that was too limited for our current needs.

For a list of accepted parameters, check [Mailchimp's Docs][docs].

[docs]: http://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash